### PR TITLE
Bridge fixes 

### DIFF
--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Ada.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Ada.purs
@@ -23,7 +23,7 @@ derive instance Generic Ada _
 derive instance Newtype Ada _
 
 instance HasConstrIndices Ada where
-  constrIndices _ = fromConstr2Index [Tuple "Lovelace" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Lovelace" 0 ]
 
 instance ToData Ada where
   toData x = genericToData x
@@ -33,5 +33,5 @@ instance FromData Ada where
 
 --------------------------------------------------------------------------------
 
-_Lovelace :: Iso' Ada {getLovelace :: BigInt}
+_Lovelace :: Iso' Ada { getLovelace :: BigInt }
 _Lovelace = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Address.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Address.purs
@@ -26,7 +26,7 @@ derive instance Generic Address _
 derive instance Newtype Address _
 
 instance HasConstrIndices Address where
-  constrIndices _ = fromConstr2Index [Tuple "Address" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Address" 0 ]
 
 instance ToData Address where
   toData x = genericToData x
@@ -36,5 +36,9 @@ instance FromData Address where
 
 --------------------------------------------------------------------------------
 
-_Address :: Iso' Address {addressCredential :: Credential, addressStakingCredential :: Maybe StakingCredential}
+_Address
+  :: Iso' Address
+       { addressCredential :: Credential
+       , addressStakingCredential :: Maybe StakingCredential
+       }
 _Address = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Bytes.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Bytes.purs
@@ -23,7 +23,7 @@ derive instance Generic LedgerBytes _
 derive instance Newtype LedgerBytes _
 
 instance HasConstrIndices LedgerBytes where
-  constrIndices _ = fromConstr2Index [Tuple "LedgerBytes" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "LedgerBytes" 0 ]
 
 instance ToData LedgerBytes where
   toData x = genericToData x
@@ -33,5 +33,5 @@ instance FromData LedgerBytes where
 
 --------------------------------------------------------------------------------
 
-_LedgerBytes :: Iso' LedgerBytes {getLedgerBytes :: ByteArray}
+_LedgerBytes :: Iso' LedgerBytes { getLedgerBytes :: ByteArray }
 _LedgerBytes = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Contexts.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Contexts.purs
@@ -43,7 +43,7 @@ derive instance Generic TxInfo _
 derive instance Newtype TxInfo _
 
 instance HasConstrIndices TxInfo where
-  constrIndices _ = fromConstr2Index [Tuple "TxInfo" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "TxInfo" 0 ]
 
 instance ToData TxInfo where
   toData x = genericToData x
@@ -53,7 +53,19 @@ instance FromData TxInfo where
 
 --------------------------------------------------------------------------------
 
-_TxInfo :: Iso' TxInfo {txInfoInputs :: Array TxInInfo, txInfoOutputs :: Array TxOut, txInfoFee :: Value, txInfoMint :: Value, txInfoDCert :: Array DCert, txInfoWdrl :: Array (Tuple StakingCredential BigInt), txInfoValidRange :: Interval POSIXTime, txInfoSignatories :: Array PubKeyHash, txInfoData :: Array (Tuple DatumHash Datum), txInfoId :: TxId}
+_TxInfo
+  :: Iso' TxInfo
+       { txInfoInputs :: Array TxInInfo
+       , txInfoOutputs :: Array TxOut
+       , txInfoFee :: Value
+       , txInfoMint :: Value
+       , txInfoDCert :: Array DCert
+       , txInfoWdrl :: Array (Tuple StakingCredential BigInt)
+       , txInfoValidRange :: Interval POSIXTime
+       , txInfoSignatories :: Array PubKeyHash
+       , txInfoData :: Array (Tuple DatumHash Datum)
+       , txInfoId :: TxId
+       }
 _TxInfo = _Newtype
 
 --------------------------------------------------------------------------------
@@ -68,7 +80,7 @@ derive instance Generic TxInInfo _
 derive instance Newtype TxInInfo _
 
 instance HasConstrIndices TxInInfo where
-  constrIndices _ = fromConstr2Index [Tuple "TxInInfo" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "TxInInfo" 0 ]
 
 instance ToData TxInInfo where
   toData x = genericToData x
@@ -78,7 +90,8 @@ instance FromData TxInInfo where
 
 --------------------------------------------------------------------------------
 
-_TxInInfo :: Iso' TxInInfo {txInInfoOutRef :: TxOutRef, txInInfoResolved :: TxOut}
+_TxInInfo
+  :: Iso' TxInInfo { txInInfoOutRef :: TxOutRef, txInInfoResolved :: TxOut }
 _TxInInfo = _Newtype
 
 --------------------------------------------------------------------------------
@@ -93,7 +106,7 @@ derive instance Generic ScriptContext _
 derive instance Newtype ScriptContext _
 
 instance HasConstrIndices ScriptContext where
-  constrIndices _ = fromConstr2Index [Tuple "ScriptContext" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "ScriptContext" 0 ]
 
 instance ToData ScriptContext where
   toData x = genericToData x
@@ -103,7 +116,9 @@ instance FromData ScriptContext where
 
 --------------------------------------------------------------------------------
 
-_ScriptContext :: Iso' ScriptContext {scriptContextTxInfo :: TxInfo, scriptContextPurpose :: ScriptPurpose}
+_ScriptContext
+  :: Iso' ScriptContext
+       { scriptContextTxInfo :: TxInfo, scriptContextPurpose :: ScriptPurpose }
 _ScriptContext = _Newtype
 
 --------------------------------------------------------------------------------
@@ -117,7 +132,12 @@ data ScriptPurpose
 derive instance Generic ScriptPurpose _
 
 instance HasConstrIndices ScriptPurpose where
-  constrIndices _ = fromConstr2Index [Tuple "Minting" 0,Tuple "Spending" 1,Tuple "Rewarding" 2,Tuple "Certifying" 3]
+  constrIndices _ = fromConstr2Index
+    [ Tuple "Minting" 0
+    , Tuple "Spending" 1
+    , Tuple "Rewarding" 2
+    , Tuple "Certifying" 3
+    ]
 
 instance ToData ScriptPurpose where
   toData x = genericToData x

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Credential.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Credential.purs
@@ -24,7 +24,8 @@ data StakingCredential
 derive instance Generic StakingCredential _
 
 instance HasConstrIndices StakingCredential where
-  constrIndices _ = fromConstr2Index [Tuple "StakingHash" 0,Tuple "StakingPtr" 1]
+  constrIndices _ = fromConstr2Index
+    [ Tuple "StakingHash" 0, Tuple "StakingPtr" 1 ]
 
 instance ToData StakingCredential where
   toData x = genericToData x
@@ -39,9 +40,10 @@ _StakingHash = prism' StakingHash case _ of
   (StakingHash a) -> Just a
   _ -> Nothing
 
-_StakingPtr :: Prism' StakingCredential {a :: BigInt, b :: BigInt, c :: BigInt}
-_StakingPtr = prism' (\{a, b, c} -> (StakingPtr a b c)) case _ of
-  (StakingPtr a b c) -> Just {a, b, c}
+_StakingPtr
+  :: Prism' StakingCredential { a :: BigInt, b :: BigInt, c :: BigInt }
+_StakingPtr = prism' (\{ a, b, c } -> (StakingPtr a b c)) case _ of
+  (StakingPtr a b c) -> Just { a, b, c }
   _ -> Nothing
 
 --------------------------------------------------------------------------------
@@ -53,7 +55,8 @@ data Credential
 derive instance Generic Credential _
 
 instance HasConstrIndices Credential where
-  constrIndices _ = fromConstr2Index [Tuple "PubKeyCredential" 0,Tuple "ScriptCredential" 1]
+  constrIndices _ = fromConstr2Index
+    [ Tuple "PubKeyCredential" 0, Tuple "ScriptCredential" 1 ]
 
 instance ToData Credential where
   toData x = genericToData x

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Crypto.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Crypto.purs
@@ -24,7 +24,7 @@ derive instance Generic PubKey _
 derive instance Newtype PubKey _
 
 instance HasConstrIndices PubKey where
-  constrIndices _ = fromConstr2Index [Tuple "PubKey" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "PubKey" 0 ]
 
 instance ToData PubKey where
   toData x = genericToData x
@@ -34,7 +34,7 @@ instance FromData PubKey where
 
 --------------------------------------------------------------------------------
 
-_PubKey :: Iso' PubKey {getPubKey :: LedgerBytes}
+_PubKey :: Iso' PubKey { getPubKey :: LedgerBytes }
 _PubKey = _Newtype
 
 --------------------------------------------------------------------------------
@@ -46,7 +46,7 @@ derive instance Generic PubKeyHash _
 derive instance Newtype PubKeyHash _
 
 instance HasConstrIndices PubKeyHash where
-  constrIndices _ = fromConstr2Index [Tuple "PubKeyHash" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "PubKeyHash" 0 ]
 
 instance ToData PubKeyHash where
   toData x = genericToData x
@@ -56,7 +56,7 @@ instance FromData PubKeyHash where
 
 --------------------------------------------------------------------------------
 
-_PubKeyHash :: Iso' PubKeyHash {getPubKeyHash :: ByteArray}
+_PubKeyHash :: Iso' PubKeyHash { getPubKeyHash :: ByteArray }
 _PubKeyHash = _Newtype
 
 --------------------------------------------------------------------------------
@@ -68,7 +68,7 @@ derive instance Generic PrivateKey _
 derive instance Newtype PrivateKey _
 
 instance HasConstrIndices PrivateKey where
-  constrIndices _ = fromConstr2Index [Tuple "PrivateKey" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "PrivateKey" 0 ]
 
 instance ToData PrivateKey where
   toData x = genericToData x
@@ -78,7 +78,7 @@ instance FromData PrivateKey where
 
 --------------------------------------------------------------------------------
 
-_PrivateKey :: Iso' PrivateKey {getPrivateKey :: LedgerBytes}
+_PrivateKey :: Iso' PrivateKey { getPrivateKey :: LedgerBytes }
 _PrivateKey = _Newtype
 
 --------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ derive instance Generic Signature _
 derive instance Newtype Signature _
 
 instance HasConstrIndices Signature where
-  constrIndices _ = fromConstr2Index [Tuple "Signature" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Signature" 0 ]
 
 instance ToData Signature where
   toData x = genericToData x
@@ -100,5 +100,5 @@ instance FromData Signature where
 
 --------------------------------------------------------------------------------
 
-_Signature :: Iso' Signature {getSignature :: ByteArray}
+_Signature :: Iso' Signature { getSignature :: ByteArray }
 _Signature = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/DCert.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/DCert.purs
@@ -29,7 +29,15 @@ data DCert
 derive instance Generic DCert _
 
 instance HasConstrIndices DCert where
-  constrIndices _ = fromConstr2Index [Tuple "DCertDelegRegKey" 0,Tuple "DCertDelegDeRegKey" 1,Tuple "DCertDelegDelegate" 2,Tuple "DCertPoolRegister" 3,Tuple "DCertPoolRetire" 4,Tuple "DCertGenesis" 5,Tuple "DCertMir" 6]
+  constrIndices _ = fromConstr2Index
+    [ Tuple "DCertDelegRegKey" 0
+    , Tuple "DCertDelegDeRegKey" 1
+    , Tuple "DCertDelegDelegate" 2
+    , Tuple "DCertPoolRegister" 3
+    , Tuple "DCertPoolRetire" 4
+    , Tuple "DCertGenesis" 5
+    , Tuple "DCertMir" 6
+    ]
 
 instance ToData DCert where
   toData x = genericToData x
@@ -49,19 +57,19 @@ _DCertDelegDeRegKey = prism' DCertDelegDeRegKey case _ of
   (DCertDelegDeRegKey a) -> Just a
   _ -> Nothing
 
-_DCertDelegDelegate :: Prism' DCert {a :: StakingCredential, b :: PubKeyHash}
-_DCertDelegDelegate = prism' (\{a, b} -> (DCertDelegDelegate a b)) case _ of
-  (DCertDelegDelegate a b) -> Just {a, b}
+_DCertDelegDelegate :: Prism' DCert { a :: StakingCredential, b :: PubKeyHash }
+_DCertDelegDelegate = prism' (\{ a, b } -> (DCertDelegDelegate a b)) case _ of
+  (DCertDelegDelegate a b) -> Just { a, b }
   _ -> Nothing
 
-_DCertPoolRegister :: Prism' DCert {a :: PubKeyHash, b :: PubKeyHash}
-_DCertPoolRegister = prism' (\{a, b} -> (DCertPoolRegister a b)) case _ of
-  (DCertPoolRegister a b) -> Just {a, b}
+_DCertPoolRegister :: Prism' DCert { a :: PubKeyHash, b :: PubKeyHash }
+_DCertPoolRegister = prism' (\{ a, b } -> (DCertPoolRegister a b)) case _ of
+  (DCertPoolRegister a b) -> Just { a, b }
   _ -> Nothing
 
-_DCertPoolRetire :: Prism' DCert {a :: PubKeyHash, b :: BigInt}
-_DCertPoolRetire = prism' (\{a, b} -> (DCertPoolRetire a b)) case _ of
-  (DCertPoolRetire a b) -> Just {a, b}
+_DCertPoolRetire :: Prism' DCert { a :: PubKeyHash, b :: BigInt }
+_DCertPoolRetire = prism' (\{ a, b } -> (DCertPoolRetire a b)) case _ of
+  (DCertPoolRetire a b) -> Just { a, b }
   _ -> Nothing
 
 _DCertGenesis :: Prism' DCert Unit

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Interval.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Interval.purs
@@ -25,7 +25,7 @@ derive instance Generic (Interval a) _
 derive instance Newtype (Interval a) _
 
 instance HasConstrIndices (Interval a) where
-  constrIndices _ = fromConstr2Index [Tuple "Interval" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Interval" 0 ]
 
 instance (ToData a) => ToData (Interval a) where
   toData x = genericToData x
@@ -35,7 +35,9 @@ instance (FromData a) => FromData (Interval a) where
 
 --------------------------------------------------------------------------------
 
-_Interval :: forall a. Iso' (Interval a) {ivFrom :: LowerBound a, ivTo :: UpperBound a}
+_Interval
+  :: forall a
+   . Iso' (Interval a) { ivFrom :: LowerBound a, ivTo :: UpperBound a }
 _Interval = _Newtype
 
 --------------------------------------------------------------------------------
@@ -45,7 +47,7 @@ data LowerBound a = LowerBound (Extended a) Boolean
 derive instance Generic (LowerBound a) _
 
 instance HasConstrIndices (LowerBound a) where
-  constrIndices _ = fromConstr2Index [Tuple "LowerBound" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "LowerBound" 0 ]
 
 instance (ToData a) => ToData (LowerBound a) where
   toData x = genericToData x
@@ -55,8 +57,9 @@ instance (FromData a) => FromData (LowerBound a) where
 
 --------------------------------------------------------------------------------
 
-_LowerBound :: forall a. Iso' (LowerBound a) {a :: Extended a, b :: Boolean}
-_LowerBound = iso (\(LowerBound a b) -> {a, b}) (\{a, b} -> (LowerBound a b))
+_LowerBound :: forall a. Iso' (LowerBound a) { a :: Extended a, b :: Boolean }
+_LowerBound = iso (\(LowerBound a b) -> { a, b })
+  (\{ a, b } -> (LowerBound a b))
 
 --------------------------------------------------------------------------------
 
@@ -65,7 +68,7 @@ data UpperBound a = UpperBound (Extended a) Boolean
 derive instance Generic (UpperBound a) _
 
 instance HasConstrIndices (UpperBound a) where
-  constrIndices _ = fromConstr2Index [Tuple "UpperBound" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "UpperBound" 0 ]
 
 instance (ToData a) => ToData (UpperBound a) where
   toData x = genericToData x
@@ -75,8 +78,9 @@ instance (FromData a) => FromData (UpperBound a) where
 
 --------------------------------------------------------------------------------
 
-_UpperBound :: forall a. Iso' (UpperBound a) {a :: Extended a, b :: Boolean}
-_UpperBound = iso (\(UpperBound a b) -> {a, b}) (\{a, b} -> (UpperBound a b))
+_UpperBound :: forall a. Iso' (UpperBound a) { a :: Extended a, b :: Boolean }
+_UpperBound = iso (\(UpperBound a b) -> { a, b })
+  (\{ a, b } -> (UpperBound a b))
 
 --------------------------------------------------------------------------------
 
@@ -88,7 +92,8 @@ data Extended a
 derive instance Generic (Extended a) _
 
 instance HasConstrIndices (Extended a) where
-  constrIndices _ = fromConstr2Index [Tuple "NegInf" 0,Tuple "Finite" 1,Tuple "PosInf" 2]
+  constrIndices _ = fromConstr2Index
+    [ Tuple "NegInf" 0, Tuple "Finite" 1, Tuple "PosInf" 2 ]
 
 instance (ToData a) => ToData (Extended a) where
   toData x = genericToData x

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Scripts.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Scripts.purs
@@ -24,7 +24,7 @@ derive instance Generic Redeemer _
 derive instance Newtype Redeemer _
 
 instance HasConstrIndices Redeemer where
-  constrIndices _ = fromConstr2Index [Tuple "Redeemer" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Redeemer" 0 ]
 
 instance ToData Redeemer where
   toData x = genericToData x
@@ -34,7 +34,7 @@ instance FromData Redeemer where
 
 --------------------------------------------------------------------------------
 
-_Redeemer :: Iso' Redeemer {getRedeemer :: PlutusData}
+_Redeemer :: Iso' Redeemer { getRedeemer :: PlutusData }
 _Redeemer = _Newtype
 
 --------------------------------------------------------------------------------
@@ -46,7 +46,7 @@ derive instance Generic Datum _
 derive instance Newtype Datum _
 
 instance HasConstrIndices Datum where
-  constrIndices _ = fromConstr2Index [Tuple "Datum" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Datum" 0 ]
 
 instance ToData Datum where
   toData x = genericToData x
@@ -56,7 +56,7 @@ instance FromData Datum where
 
 --------------------------------------------------------------------------------
 
-_Datum :: Iso' Datum {getDatum :: PlutusData}
+_Datum :: Iso' Datum { getDatum :: PlutusData }
 _Datum = _Newtype
 
 --------------------------------------------------------------------------------
@@ -68,7 +68,7 @@ derive instance Generic ScriptHash _
 derive instance Newtype ScriptHash _
 
 instance HasConstrIndices ScriptHash where
-  constrIndices _ = fromConstr2Index [Tuple "ScriptHash" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "ScriptHash" 0 ]
 
 instance ToData ScriptHash where
   toData x = genericToData x
@@ -78,7 +78,7 @@ instance FromData ScriptHash where
 
 --------------------------------------------------------------------------------
 
-_ScriptHash :: Iso' ScriptHash {getScriptHash :: ByteArray}
+_ScriptHash :: Iso' ScriptHash { getScriptHash :: ByteArray }
 _ScriptHash = _Newtype
 
 --------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ derive instance Generic ValidatorHash _
 derive instance Newtype ValidatorHash _
 
 instance HasConstrIndices ValidatorHash where
-  constrIndices _ = fromConstr2Index [Tuple "ValidatorHash" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "ValidatorHash" 0 ]
 
 instance ToData ValidatorHash where
   toData x = genericToData x
@@ -112,7 +112,7 @@ derive instance Generic DatumHash _
 derive instance Newtype DatumHash _
 
 instance HasConstrIndices DatumHash where
-  constrIndices _ = fromConstr2Index [Tuple "DatumHash" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "DatumHash" 0 ]
 
 instance ToData DatumHash where
   toData x = genericToData x
@@ -134,7 +134,7 @@ derive instance Generic MintingPolicyHash _
 derive instance Newtype MintingPolicyHash _
 
 instance HasConstrIndices MintingPolicyHash where
-  constrIndices _ = fromConstr2Index [Tuple "MintingPolicyHash" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "MintingPolicyHash" 0 ]
 
 instance ToData MintingPolicyHash where
   toData x = genericToData x
@@ -156,7 +156,7 @@ derive instance Generic StakeValidatorHash _
 derive instance Newtype StakeValidatorHash _
 
 instance HasConstrIndices StakeValidatorHash where
-  constrIndices _ = fromConstr2Index [Tuple "StakeValidatorHash" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "StakeValidatorHash" 0 ]
 
 instance ToData StakeValidatorHash where
   toData x = genericToData x

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Slot.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Slot.purs
@@ -23,7 +23,7 @@ derive instance Generic Slot _
 derive instance Newtype Slot _
 
 instance HasConstrIndices Slot where
-  constrIndices _ = fromConstr2Index [Tuple "Slot" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Slot" 0 ]
 
 instance ToData Slot where
   toData x = genericToData x
@@ -33,5 +33,5 @@ instance FromData Slot where
 
 --------------------------------------------------------------------------------
 
-_Slot :: Iso' Slot {getSlot :: BigInt}
+_Slot :: Iso' Slot { getSlot :: BigInt }
 _Slot = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Time.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Time.purs
@@ -23,7 +23,7 @@ derive instance Generic DiffMilliSeconds _
 derive instance Newtype DiffMilliSeconds _
 
 instance HasConstrIndices DiffMilliSeconds where
-  constrIndices _ = fromConstr2Index [Tuple "DiffMilliSeconds" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "DiffMilliSeconds" 0 ]
 
 instance ToData DiffMilliSeconds where
   toData x = genericToData x
@@ -45,7 +45,7 @@ derive instance Generic POSIXTime _
 derive instance Newtype POSIXTime _
 
 instance HasConstrIndices POSIXTime where
-  constrIndices _ = fromConstr2Index [Tuple "POSIXTime" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "POSIXTime" 0 ]
 
 instance ToData POSIXTime where
   toData x = genericToData x
@@ -55,5 +55,5 @@ instance FromData POSIXTime where
 
 --------------------------------------------------------------------------------
 
-_POSIXTime :: Iso' POSIXTime {getPOSIXTime :: BigInt}
+_POSIXTime :: Iso' POSIXTime { getPOSIXTime :: BigInt }
 _POSIXTime = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Tx.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Tx.purs
@@ -31,7 +31,7 @@ derive instance Generic TxOut _
 derive instance Newtype TxOut _
 
 instance HasConstrIndices TxOut where
-  constrIndices _ = fromConstr2Index [Tuple "TxOut" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "TxOut" 0 ]
 
 instance ToData TxOut where
   toData x = genericToData x
@@ -41,7 +41,12 @@ instance FromData TxOut where
 
 --------------------------------------------------------------------------------
 
-_TxOut :: Iso' TxOut {txOutAddress :: Address, txOutValue :: Value, txOutDatumHash :: Maybe DatumHash}
+_TxOut
+  :: Iso' TxOut
+       { txOutAddress :: Address
+       , txOutValue :: Value
+       , txOutDatumHash :: Maybe DatumHash
+       }
 _TxOut = _Newtype
 
 --------------------------------------------------------------------------------
@@ -56,7 +61,7 @@ derive instance Generic TxOutRef _
 derive instance Newtype TxOutRef _
 
 instance HasConstrIndices TxOutRef where
-  constrIndices _ = fromConstr2Index [Tuple "TxOutRef" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "TxOutRef" 0 ]
 
 instance ToData TxOutRef where
   toData x = genericToData x
@@ -66,5 +71,5 @@ instance FromData TxOutRef where
 
 --------------------------------------------------------------------------------
 
-_TxOutRef :: Iso' TxOutRef {txOutRefId :: TxId, txOutRefIdx :: BigInt}
+_TxOutRef :: Iso' TxOutRef { txOutRefId :: TxId, txOutRefIdx :: BigInt }
 _TxOutRef = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/TxId.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/TxId.purs
@@ -23,7 +23,7 @@ derive instance Generic TxId _
 derive instance Newtype TxId _
 
 instance HasConstrIndices TxId where
-  constrIndices _ = fromConstr2Index [Tuple "TxId" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "TxId" 0 ]
 
 instance ToData TxId where
   toData x = genericToData x
@@ -33,5 +33,5 @@ instance FromData TxId where
 
 --------------------------------------------------------------------------------
 
-_TxId :: Iso' TxId {getTxId :: ByteArray}
+_TxId :: Iso' TxId { getTxId :: ByteArray }
 _TxId = _Newtype

--- a/plutus-ledger-api-typelib/Plutus/V1/Ledger/Value.purs
+++ b/plutus-ledger-api-typelib/Plutus/V1/Ledger/Value.purs
@@ -25,7 +25,7 @@ derive instance Generic Value _
 derive instance Newtype Value _
 
 instance HasConstrIndices Value where
-  constrIndices _ = fromConstr2Index [Tuple "Value" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Value" 0 ]
 
 instance ToData Value where
   toData x = genericToData x
@@ -35,7 +35,7 @@ instance FromData Value where
 
 --------------------------------------------------------------------------------
 
-_Value :: Iso' Value {getValue :: Map CurrencySymbol (Map TokenName BigInt)}
+_Value :: Iso' Value { getValue :: Map CurrencySymbol (Map TokenName BigInt) }
 _Value = _Newtype
 
 --------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ derive instance Generic CurrencySymbol _
 derive instance Newtype CurrencySymbol _
 
 instance HasConstrIndices CurrencySymbol where
-  constrIndices _ = fromConstr2Index [Tuple "CurrencySymbol" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "CurrencySymbol" 0 ]
 
 instance ToData CurrencySymbol where
   toData x = genericToData x
@@ -57,19 +57,20 @@ instance FromData CurrencySymbol where
 
 --------------------------------------------------------------------------------
 
-_CurrencySymbol :: Iso' CurrencySymbol {unCurrencySymbol :: ByteArray}
+_CurrencySymbol :: Iso' CurrencySymbol { unCurrencySymbol :: ByteArray }
 _CurrencySymbol = _Newtype
 
 --------------------------------------------------------------------------------
 
-newtype AssetClass = AssetClass { unAssetClass :: Tuple CurrencySymbol TokenName }
+newtype AssetClass = AssetClass
+  { unAssetClass :: Tuple CurrencySymbol TokenName }
 
 derive instance Generic AssetClass _
 
 derive instance Newtype AssetClass _
 
 instance HasConstrIndices AssetClass where
-  constrIndices _ = fromConstr2Index [Tuple "AssetClass" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "AssetClass" 0 ]
 
 instance ToData AssetClass where
   toData x = genericToData x
@@ -79,7 +80,8 @@ instance FromData AssetClass where
 
 --------------------------------------------------------------------------------
 
-_AssetClass :: Iso' AssetClass {unAssetClass :: Tuple CurrencySymbol TokenName}
+_AssetClass
+  :: Iso' AssetClass { unAssetClass :: Tuple CurrencySymbol TokenName }
 _AssetClass = _Newtype
 
 --------------------------------------------------------------------------------
@@ -91,7 +93,7 @@ derive instance Generic TokenName _
 derive instance Newtype TokenName _
 
 instance HasConstrIndices TokenName where
-  constrIndices _ = fromConstr2Index [Tuple "TokenName" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "TokenName" 0 ]
 
 instance ToData TokenName where
   toData x = genericToData x
@@ -101,5 +103,5 @@ instance FromData TokenName where
 
 --------------------------------------------------------------------------------
 
-_TokenName :: Iso' TokenName {unTokenName :: ByteArray}
+_TokenName :: Iso' TokenName { unTokenName :: ByteArray }
 _TokenName = _Newtype

--- a/plutus-ledger-api-typelib/PlutusTx/AssocMap.purs
+++ b/plutus-ledger-api-typelib/PlutusTx/AssocMap.purs
@@ -22,7 +22,7 @@ derive instance Generic (Map a b) _
 derive instance Newtype (Map a b) _
 
 instance HasConstrIndices (Map a b) where
-  constrIndices _ = fromConstr2Index [Tuple "Map" 0]
+  constrIndices _ = fromConstr2Index [ Tuple "Map" 0 ]
 
 instance (ToData a, ToData b) => ToData (Map a b) where
   toData x = genericToData x
@@ -32,5 +32,5 @@ instance (FromData a, FromData b) => FromData (Map a b) where
 
 --------------------------------------------------------------------------------
 
-_Map :: forall a b. Iso' (Map a b) {unMap :: Array (Tuple a b)}
+_Map :: forall a b. Iso' (Map a b) { unMap :: Array (Tuple a b) }
 _Map = _Newtype

--- a/src/PlutusTx/LedgerTypes.hs
+++ b/src/PlutusTx/LedgerTypes.hs
@@ -112,16 +112,10 @@ ledgerTypes =
 -- My assumption was that, like Plutarch, we'd just shove everything into it's respective Plutus.V1.Ledger module
 plutusBridge :: BridgeBuilder PSType
 plutusBridge =
-  -- cbtxBridge "Plutus.V1.Ledger.Value" "Value" "Types.Value" "Value"
-  --  <|> cbtxBridge "Plutus.V1.Ledger.Value" "CurrencySymbol" "Types.Value" "CurrencySymbol"
-  --  <|> cbtxBridge "Plutus.V1.Ledger.Value" "TokenName" "Types.Value" "TokenName"
-  --  <|> cbtxBridge "Plutus.V1.Ledger.Address" "Address" "Serialization.Address" "Address"
   cbtxBridge "PlutusTx.Builtins.Internal" "BuiltinByteString" "Types.ByteArray" "ByteArray"
     <|> cbtxBridge "PlutusTx.Builtins.Internal" "BuiltinData" "Types.PlutusData" "PlutusData"
-    --  <|> cbtxBridge "Plutus.V1.Ledger.Bytes" "LedgerBytes" "Types.ByteArray" "ByteArray"
-    -- <|> cbtxBridge "Plutus.V1.Ledger.Time" "POSIXTime" "Types.Interval" "POSIXTime"
     <|> cbtxBridge "GHC.Integer.Type" "Integer" "Data.BigInt" "BigInt"
-    <|> cbtxBridge "PlutusTx.Ratio" "Rational" "Data.Rational" "Rational"
+    <|> cbtxBridge "PlutusTx.Ratio" "Rational" "Types.Rational" "Rational"
 
 --  <|> assetClassBridge
 


### PR DESCRIPTION
I'm going to merge this instantly but just to document: 

We have 

```haskell
plutusBridge :: BridgeBuilder PSType
plutusBridge =
  cbtxBridge "PlutusTx.Builtins.Internal" "BuiltinByteString" "Types.ByteArray" "ByteArray"
    <|> cbtxBridge "PlutusTx.Builtins.Internal" "BuiltinData" "Types.PlutusData" "PlutusData"
    <|> cbtxBridge "GHC.Integer.Type" "Integer" "Data.BigInt" "BigInt"
    <|> cbtxBridge "PlutusTx.Ratio" "Rational" "Data.Rational" "Rational"
```
Which pulls the `Rational` type from _PureScript_'s `Data.Rational`, which is not what we want (because it's defined as `Ratio Int`). We need to pull from CTL's `Types.Rational` module instead. This PR fixes that. 

I also updated the Ledger types on the assumption that this fixes our issues. 
